### PR TITLE
Fix how upgrade service tag is specified in the default values

### DIFF
--- a/charts/cht-chart-4x/values.yaml
+++ b/charts/cht-chart-4x/values.yaml
@@ -8,7 +8,7 @@ upstream_servers:
   docker_registry: "public.ecr.aws/medic"
   builds_url: "https://staging.dev.medicmobile.org/_couch/builds_4"
 upgrade_service:
-  tag: medicmobile/upgrade-service:0.32
+  tag: 0.32
 
 # CouchDB Settings
 couchdb:


### PR DESCRIPTION
Because of the way the tag is interpolated into [the template](https://github.com/medic/helm-charts/blob/main/charts/cht-chart-4x/templates/upgrade-service-deployment.yml#L25), only the number needs to be specified. Otherwise, the image tag becomes: `medicmobile/upgrade-service:medicmobile/upgrade-service:0.32` - causing an invalid image tag error. A very simple fix but a tricky bug.