### PR TITLE
Use root for couchdb container

### DIFF
--- a/charts/cht-chart-4x/Chart.yaml
+++ b/charts/cht-chart-4x/Chart.yaml
@@ -6,6 +6,6 @@ icon: https://avatars.githubusercontent.com/u/474424?s=200&v=4
 
 type: application
 
-version: 1.0.0
+version: 1.0.1
 
 appVersion: ""

--- a/charts/cht-chart-4x/templates/couchdb-n-deployment.yaml
+++ b/charts/cht-chart-4x/templates/couchdb-n-deployment.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         cht.service: couchdb-{{ $nodeNumber }}
     spec:
+      securityContext:
+        runAsUser: 0  # Run as root
+        fsGroup: 0    # Set fsGroup to root
       tolerations:
       - key: {{ $root.Values.toleration.key }}
         operator: {{ $root.Values.toleration.operator }}

--- a/charts/cht-chart-4x/templates/couchdb-single-deployment.yaml
+++ b/charts/cht-chart-4x/templates/couchdb-single-deployment.yaml
@@ -17,6 +17,9 @@ spec:
       labels:
         cht.service: couchdb
     spec:
+      securityContext:
+        runAsUser: 0  # Run as root
+        fsGroup: 0    # Set fsGroup to root
       tolerations:
         - key: {{ .Values.toleration.key }}
           operator: {{ .Values.toleration.operator }}


### PR DESCRIPTION
The container shouldn't run into access issues when mounting volumes with pre-existing data.