### PR TITLE
add custom partitions, allow numbered directories for subPath for multiple nodes

### DIFF
--- a/charts/cht-chart-4x/Chart.yaml
+++ b/charts/cht-chart-4x/Chart.yaml
@@ -6,6 +6,6 @@ icon: https://avatars.githubusercontent.com/u/474424?s=200&v=4
 
 type: application
 
-version: 1.1.0
+version: 1.1.1
 
 appVersion: ""

--- a/charts/cht-chart-4x/templates/couchdb-n-deployment.yaml
+++ b/charts/cht-chart-4x/templates/couchdb-n-deployment.yaml
@@ -84,9 +84,17 @@ spec:
         volumeMounts:
         - mountPath: /opt/couchdb/data
           name: couchdb-{{ $nodeNumber }}-claim0
-          {{- if ne .Values.couchdb_data.dataPathOnDiskForCouchDB "" }}
-          subPath: {{ .Values.couchdb_data.dataPathOnDiskForCouchDB }}
+          {{- if $.Values.couchdb_data.dataPathOnDiskForCouchDB }}
+          subPath: {{ if contains "%d" $.Values.couchdb_data.dataPathOnDiskForCouchDB }}
+                    {{- printf $.Values.couchdb_data.dataPathOnDiskForCouchDB $nodeNumber }}
+                    {{- else }}
+                    {{- $.Values.couchdb_data.dataPathOnDiskForCouchDB }}
+                    {{- end }}
           {{- end }}
+          # You can use %d for each node to be substituted with the node number.
+          # If %d doesn't exist, the same path will be used for all nodes.
+          # example: test-path%d will be test-path1, test-path2, test-path3 for 3 nodes.
+          # example: test-path will be test-path for all nodes.
         - mountPath: /opt/couchdb/etc/local.d
           name: couchdb-{{ $nodeNumber }}-claim0
           subPath: local.d

--- a/charts/cht-chart-4x/templates/couchdb-n-persistentvolume.yaml
+++ b/charts/cht-chart-4x/templates/couchdb-n-persistentvolume.yaml
@@ -21,7 +21,7 @@ spec:
     volumeHandle: {{ index $.Values.ebs (printf "preExistingEBSVolumeID-%d" $nodeNumber) }}
     fsType: ext4
     volumeAttributes:
-      partition: "0"
+      partition: "{{ $.Values.couchdb_data.partition | default "0" }}"
   {{- else if eq $.Values.cluster_type "k3s-k3d" }}
   storageClassName: {{ if and ($.Values.k3s_use_vSphere_storage_class) (eq (toString $.Values.k3s_use_vSphere_storage_class) "true") }}vsphere-storage-class{{ else }}local-storage{{ end }}
   {{- if and ($.Values.k3s_use_vSphere_storage_class) (eq (toString $.Values.k3s_use_vSphere_storage_class) "true") }}

--- a/charts/cht-chart-4x/templates/couchdb-persistentvolume.yaml
+++ b/charts/cht-chart-4x/templates/couchdb-persistentvolume.yaml
@@ -15,5 +15,5 @@ spec:
     volumeHandle: {{ index .Values.ebs "preExistingEBSVolumeID-1" }}
     fsType: ext4
     volumeAttributes:
-      partition: "0"
+      partition: "{{ .Values.couchdb_data.partition | default "0" }}"
 {{- end }}

--- a/charts/cht-chart-4x/values.yaml
+++ b/charts/cht-chart-4x/values.yaml
@@ -69,6 +69,12 @@ couchdb_data:
     # To mount to a specific subpath (If data is from an old 3.x instance for example): dataPathOnDiskForCouchDB: "storage/medic-core/couchdb/data"
     # To mount to the root of the volume: dataPathOnDiskForCouchDB: ""
     # To use the default "data" subpath, remove the subPath line entirely from values.yaml or name it "data" or use null.
+    # for Multi-node configuration, you can use %d to substitute with the node number.
+    # You can use %d for each node to be substituted with the node number.
+    # If %d doesn't exist, the same path will be used for all nodes.
+    # example: test-path%d will be test-path1, test-path2, test-path3 for 3 nodes.
+    # example: test-path will be test-path for all nodes.
+  partition: "0" # This is the partition number for the EBS volume. Leave it as 0 if you don't have a partitioned disk.
 
 # If preExistingDataAvailable is true, fill in the details below.
 # For local_storage, fill in the details if you are using k3s-k3d cluster type.


### PR DESCRIPTION
* Allow customizing partition, 
* Support sequentially numbered directories for clustered setup (i.e. Node1 can have subPath: srv1 while node2 can have subPath: srv2. The subPath config would be saved as `srv%d` in the values. The code replaces %d with the node number.