### PR TITLE
Add cht-user-managment-worker and redis to cht-user-management helm charts

### DIFF
--- a/charts/base-single-app/Chart.yaml
+++ b/charts/base-single-app/Chart.yaml
@@ -4,8 +4,8 @@ description: Single app helm chart to simplify configuration
 home: https://github.com/medic/helm-charts/tree/gh-pages
 icon: https://avatars.githubusercontent.com/u/474424?s=200&v=4
 
-type: library
+type: application
 
-version: 0.2.1
+version: 0.2.2
 
 appVersion: ""

--- a/charts/base-single-app/templates/deployment.yaml
+++ b/charts/base-single-app/templates/deployment.yaml
@@ -36,10 +36,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            {{- if .Values.service.port }}
+          {{- if .Values.service.enabled }}
             - name: PORT
               value: "{{ .Values.service.port }}"
-            {{- end }}
+          {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
@@ -51,7 +51,7 @@ spec:
                   name: "{{ tpl (.secretName | toString) $ }}"
                   key: "{{ .secretKey | default .env }}"
             {{- end }}
-          {{- if .Values.service.port }}
+          {{- if .Values.service.enabled }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/base-single-app/templates/deployment.yaml
+++ b/charts/base-single-app/templates/deployment.yaml
@@ -36,8 +36,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            {{- if .Values.service.port }}
             - name: PORT
               value: "{{ .Values.service.port }}"
+            {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
@@ -49,6 +51,7 @@ spec:
                   name: "{{ tpl (.secretName | toString) $ }}"
                   key: "{{ .secretKey | default .env }}"
             {{- end }}
+          {{- if .Values.service.port }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -61,6 +64,7 @@ spec:
             httpGet:
               path: /_healthz
               port: http
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}

--- a/charts/base-single-app/templates/service.yaml
+++ b/charts/base-single-app/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       name: http
   selector:
     {{- include "base-single-app.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/base-single-app/templates/service.yaml
+++ b/charts/base-single-app/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.service }}
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/cht-user-management/Chart.lock
+++ b/charts/cht-user-management/Chart.lock
@@ -2,5 +2,11 @@ dependencies:
 - name: base-single-app
   repository: https://docs.communityhealthtoolkit.org/helm-charts
   version: 0.2.0
-digest: sha256:284a3dc5e9eb4c400a3abff6f49faa047ad11d2dbbc873e8adf8829cde321aae
-generated: "2024-04-10T11:32:50.118338+02:00"
+- name: base-single-app
+  repository: https://docs.communityhealthtoolkit.org/helm-charts
+  version: 0.2.0
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.13.2
+digest: sha256:7ab3acf9fe6ac215c38d90edfeed99afa631c929674aa923f2e607c63ce17c76
+generated: "2024-10-27T21:42:14.879031-06:00"

--- a/charts/cht-user-management/Chart.lock
+++ b/charts/cht-user-management/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: base-single-app
-  repository: https://docs.communityhealthtoolkit.org/helm-charts
-  version: 0.2.0
+  repository: file://../base-single-app
+  version: 0.2.2
 - name: base-single-app
-  repository: https://docs.communityhealthtoolkit.org/helm-charts
-  version: 0.2.0
+  repository: file://../base-single-app
+  version: 0.2.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.13.2
-digest: sha256:7ab3acf9fe6ac215c38d90edfeed99afa631c929674aa923f2e607c63ce17c76
-generated: "2024-10-27T21:42:14.879031-06:00"
+digest: sha256:cd591bdfad18b05b5cc473ffd5796b630ac8e10248ae6e7ca4f0b716e78369a2
+generated: "2024-10-29T16:04:11.007238-06:00"

--- a/charts/cht-user-management/Chart.yaml
+++ b/charts/cht-user-management/Chart.yaml
@@ -6,18 +6,18 @@ icon: https://avatars.githubusercontent.com/u/474424?s=200&v=4
 
 type: application
 
-version: 0.2.1
+version: 0.2.2
 
 dependencies:
   - alias: cht-user-management
     name: base-single-app
-    version: "0.2.0"
+    version: "0.2.2"
     #repository: file://../base-single-app
     repository: https://docs.communityhealthtoolkit.org/helm-charts
 
   - alias: cht-user-management-worker
     name: base-single-app
-    version: "0.2.0"
+    version: "0.2.2"
     repository: https://docs.communityhealthtoolkit.org/helm-charts
     #repository: file://../base-single-app
 

--- a/charts/cht-user-management/Chart.yaml
+++ b/charts/cht-user-management/Chart.yaml
@@ -12,7 +12,18 @@ dependencies:
   - alias: cht-user-management
     name: base-single-app
     version: "0.2.0"
+    #repository: file://../base-single-app
     repository: https://docs.communityhealthtoolkit.org/helm-charts
-    # repository: file://../base-single-app
+
+  - alias: cht-user-management-worker
+    name: base-single-app
+    version: "0.2.0"
+    repository: https://docs.communityhealthtoolkit.org/helm-charts
+    #repository: file://../base-single-app
+
+  - alias: redis
+    name: redis
+    version: "16.13.2"
+    repository: https://charts.bitnami.com/bitnami
 
 appVersion: ""

--- a/charts/cht-user-management/templates/_secret.tpl
+++ b/charts/cht-user-management/templates/_secret.tpl
@@ -17,12 +17,21 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
-Looks if there is an existing secret and reuse its key. If not generate a new key and use it.
+Looks if there is existing secrets and reuse their keys. If not generate new keys and use them.
 */}}
 {{- define "chtUserManagement.COOKIE_PRIVATE_KEY" -}}
 {{- $secret := (lookup "v1" "Secret" (.Release.Namespace) (include "chtUserManagement.fullname" .) ) }}
 {{- if $secret }}
 {{- index $secret "data" "COOKIE_PRIVATE_KEY" }}
+{{- else }}
+{{- (randAlphaNum 45) | b64enc | quote }}
+{{- end }}
+{{- end }}
+
+{{- define "chtUserManagement.WORKER_PRIVATE_KEY" -}}
+{{- $secret := (lookup "v1" "Secret" (.Release.Namespace) (include "chtUserManagement.fullname" .) ) }}
+{{- if $secret }}
+{{- index $secret "data" "WORKER_PRIVATE_KEY" }}
 {{- else }}
 {{- (randAlphaNum 45) | b64enc | quote }}
 {{- end }}

--- a/charts/cht-user-management/templates/secret.yaml
+++ b/charts/cht-user-management/templates/secret.yaml
@@ -7,3 +7,4 @@ metadata:
 type: Opaque
 data:
   COOKIE_PRIVATE_KEY: {{ include "chtUserManagement.COOKIE_PRIVATE_KEY" . }}
+  WORKER_PRIVATE_KEY: {{ include "chtUserManagement.WORKER_PRIVATE_KEY" . }}

--- a/charts/cht-user-management/values.yaml
+++ b/charts/cht-user-management/values.yaml
@@ -1,19 +1,73 @@
 cht-user-management:
   replicaCount: 1
-
   service:
     port: 3000
-
   image:
     repository: public.ecr.aws/medic/cht-user-management
-    tag: ""  # Set this to the version of the docker image
+    tag: "1.4.1"  # Set this to the version of the docker image
 
   # Environment variablues to set in the pod, for example:
   # env:
   #   CONFIG_NAME: changeme
-  env: {}
-
+  env: 
+    NODE_ENV: dev
+    CHT_DEV_HTTP: true
+    CHT_DEV_URL_PORT: hareet-test.dev.medicmobile.org
+    CONFIG_NAME: chis-tg
+    REDIS_HOST: test-user-management-redis-master.hareet-test.svc.cluster.local
+    REDIS_PORT: 6379
   envSecrets:
     # COOKIE_PRIVATE_KEY will be automatically generated if it doesn't exist
     - env: COOKIE_PRIVATE_KEY
-      secretName: '{{ include "chtUserManagement.fullname" . }}'
+      secretName: test-user-management-cht-user-management
+    - env: WORKER_PRIVATE_KEY
+      secretName: test-user-management-cht-user-management
+  
+  ingress:
+    annotations:
+      alb.ingress.kubernetes.io/certificate-arn: arn:aws:iam::720541322708:server-certificate/2024-wildcard-dev-medicmobile-org-chain
+      alb.ingress.kubernetes.io/group.name: dev-cht-alb
+      alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/ssl-redirect: "443"
+      alb.ingress.kubernetes.io/tags: Environment=dev,Team=QA
+      alb.ingress.kubernetes.io/target-type: ip
+    className: alb
+    enabled: true
+    hosts:
+    - host: hareet-test-users.dev.medicmobile.org
+      paths:
+      - path: /
+        pathType: Prefix
+
+
+cht-user-management-worker:
+  replicaCount: 1
+  image:
+    repository: public.ecr.aws/medic/cht-user-management-worker
+    tag: "1.4.1"
+  env: 
+    NODE_ENV: dev
+    REDIS_HOST: test-user-management-redis-master.hareet-test.svc.cluster.local
+    REDIS_PORT: 6379
+  envSecrets:
+    - env: WORKER_PRIVATE_KEY
+      secretName: test-user-management-cht-user-management
+
+
+redis:
+  architecture: standalone
+  replica:
+    replicaCount: 1
+  persistence:
+    enabled: true
+    storageClass: ebs-gp2
+    size: 8Gi
+  auth:
+    enabled: false
+
+
+# helm -n hareet-test install test-user-management -f values.yaml ./cht-user-management
+
+

--- a/charts/cht-user-management/values.yaml
+++ b/charts/cht-user-management/values.yaml
@@ -2,6 +2,7 @@ cht-user-management:
   replicaCount: 1
   service:
     port: 3000
+    enabled: true
   image:
     repository: public.ecr.aws/medic/cht-user-management
     tag: "1.4.1"  # Set this to the version of the docker image
@@ -9,19 +10,20 @@ cht-user-management:
   # Environment variablues to set in the pod, for example:
   # env:
   #   CONFIG_NAME: changeme
+  #   REDIS_HOST: {{ Release.Name }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local
   env: 
     NODE_ENV: dev
-    CHT_DEV_HTTP: true
+    CHT_DEV_HTTP: false
     CHT_DEV_URL_PORT: hareet-test.dev.medicmobile.org
     CONFIG_NAME: chis-tg
     REDIS_HOST: test-user-management-redis-master.hareet-test.svc.cluster.local
     REDIS_PORT: 6379
   envSecrets:
-    # COOKIE_PRIVATE_KEY will be automatically generated if it doesn't exist
+    # COOKIE/WORKER_PRIVATE_KEY will be automatically generated if it doesn't exist
     - env: COOKIE_PRIVATE_KEY
-      secretName: test-user-management-cht-user-management
+      secretName: "{{ .Release.Name }}-cht-user-management"
     - env: WORKER_PRIVATE_KEY
-      secretName: test-user-management-cht-user-management
+      secretName: "{{ .Release.Name }}-cht-user-management"
   
   ingress:
     annotations:
@@ -43,6 +45,10 @@ cht-user-management:
 
 
 cht-user-management-worker:
+  # Our worker does not need any ports exposed, services, healtchecks, so we toggle this to false
+  # to prevent single-base-app from templating and creating those resources
+  service:
+    enabled: false
   replicaCount: 1
   image:
     repository: public.ecr.aws/medic/cht-user-management-worker
@@ -53,7 +59,7 @@ cht-user-management-worker:
     REDIS_PORT: 6379
   envSecrets:
     - env: WORKER_PRIVATE_KEY
-      secretName: test-user-management-cht-user-management
+      secretName: "{{ .Release.Name }}-cht-user-management"
 
 
 redis:
@@ -66,8 +72,4 @@ redis:
     size: 8Gi
   auth:
     enabled: false
-
-
-# helm -n hareet-test install test-user-management -f values.yaml ./cht-user-management
-
-
+    


### PR DESCRIPTION
Resolves [#19 ](https://github.com/medic/helm-charts/issues/19)

A few things I need to fix before merging:
- Chart.yaml in cht-user-management requires version "0.2.0" for its dependencies. If we run helm commands with `--dry-run --debug` with "0.2.1" versions listed, the manifests dont get populated for cht-user-management and worker containers. Only redis is populated. Rolling that chart depedency back to version "0.2.0" populates all manifests.
- We have some nested dependencies (cht-user-management) uses single-base-app to create its templates, and there is some version mismatching that is happening.
- We need to fix this, because we want to release single-base-app "0.2.2" which would include options around if ports, services or healthprobes are needed and that would enable us to use single-base-app for cht-user-management-worker

Current workaround:
- Deploy helm charts with Chart.yaml "0.2.0" for all single-base-app
- After deployment is running, edit cht-user-management-worker deploy resource and delete the lines referencing ports.

Testing:
- cht-core 4.9 : hareet-test.dev.medicmobile.org
   - togo config uploaded, no seed data yet
- user man tool: hareet-test-users.dev.medicmobile.org
