### PR TITLE
attempt to put in more default values for more happy path

### DIFF
--- a/charts/cht-chart-4x/values.yaml
+++ b/charts/cht-chart-4x/values.yaml
@@ -1,5 +1,5 @@
-project_name: "<your-project-name>"
-namespace: "<your-namespace>" # e.g. "cht-dev-namespace"
+project_name: "<your-project-name>" # e.g. mrjones-dev
+namespace: "<your-namespace>" # e.g. "mrjones-dev"
 chtversion: 4.10.0
 # cht_image_tag: 4.1.1-4.1.1 #- This is filled in automatically by the deploy script. Don't uncomment this line.
 
@@ -18,9 +18,9 @@ upgrade_service:
 # CouchDB Settings
 couchdb:
   password: "<password-value>" # Avoid using non-url-safe characters in password
-  secret: "<secret-value>" # Any value, e.g. a UUID.
-  user: "<user-name>"
-  uuid: "<uuid-value>" # Any UUID
+  secret: "f9053a0a-ef77-4be3-994d-87d6732600fd" # for prod, change to output of `uuidgen
+  user: "medic"
+  uuid: "7300115e-1a98-4607-a37c-50e0c9913767" # for prod, change to output of `uuidgen`
   clusteredCouch_enabled: false
   couchdb_node_storage_size: 100Mi
 clusteredCouch:
@@ -34,11 +34,11 @@ ingress:
   annotations:
     groupname: "dev-cht-alb"
     tags: "Environment=dev,Team=QA"
-    certificate: "arn:aws:iam::<account-id>:server-certificate/2024-wildcard-dev-medicmobile-org-chain"
+    certificate: "arn:aws:iam::720541322708:server-certificate/2024-wildcard-dev-medicmobile-org-chain"
   # Ensure the host is not already taken. Valid characters for a subdomain are:
   #   a-z, 0-9, and - (but not as first or last character).
-  host: "<subdomain>.dev.medicmobile.org"
-  hosted_zone_id: "<the-hosted-zone-id>"
+  host: "<subdomain>.dev.medicmobile.org"  # e.g. "mrjones.dev.medicmobile.org"
+  hosted_zone_id: "Z3304WUAJTCM7P"
   load_balancer: "dualstack.k8s-devchtalb-3eb0781cbb-694321496.eu-west-2.elb.amazonaws.com"
 
 environment: "remote"  # "local", "remote"


### PR DESCRIPTION
to help out with medic/medic-infrastructure/pull/1078

Note: in other values files we go with default `uuid` and `secret` values. I think this OK for ephemeral dev instances as per this PR, but for prod instances we should go with unique `uuidgen` output for both values.