### PR TITLE
40 add template for nouveau

### DIFF
--- a/charts/cht-chart-4x/templates/couchdb-nouveau-deployment.yaml
+++ b/charts/cht-chart-4x/templates/couchdb-nouveau-deployment.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.couchdb.nouveau_enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cht.service: nouveau
+  name: cht-couchdb-nouveau
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cht.service: nouveau
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        cht.service: nouveau
+    spec:
+      securityContext:
+        runAsUser: 0  # Run as root
+        fsGroup: 0    # Set fsGroup to root
+      tolerations:
+        - key: {{ .Values.toleration.key }}
+          operator: {{ .Values.toleration.operator }}
+          value: {{ .Values.toleration.value | quote }}
+          effect: {{ .Values.toleration.effect }}
+    {{- if hasKey .Values "nodes" }}
+      {{- if hasKey .Values.nodes "single_node_deploy" }}
+      nodeSelector:
+        kubernetes.io/hostname: {{ .Values.nodes.single_node_deploy }}
+      {{- end }}
+    {{- end }}
+      containers:
+          image: {{ .Values.upstream_servers.docker_registry }}/cht-couchdb-nouveau:{{ .Values.cht_image_tag }}
+          {{ if eq .Values.cache_images false}}imagePullPolicy: Always{{ end }}
+          name: cht-couchdb-nouveau
+          ports:
+            - containerPort: 5987
+          resources: {}
+          {{- if eq (toString .Values.cluster_type) "k3s-k3d" }}
+          volumeMounts:
+            - mountPath: /data/nouveau
+              name: local-volume
+              subPath: data
+          {{- else }}
+          volumeMounts:
+            - mountPath: /data/nouveau
+              name: couchdb-nouveau-claim0
+              subPath: data
+          {{- end }}
+      restartPolicy: Always
+      {{- if eq (toString .Values.cluster_type) "k3s-k3d" }}
+      volumes:
+        - name: local-volume
+          hostPath:
+            path: {{ index .Values.local_storage "preExistingDiskPath-1" }}
+      {{- else }}
+      volumes:
+        - name: couchdb-nouveau-claim0
+          persistentVolumeClaim:
+            claimName: couchdb-nouveau-claim0
+      {{- end }}
+status: {}
+{{- end }}

--- a/charts/cht-chart-4x/templates/couchdb-nouveau-deployment.yaml
+++ b/charts/cht-chart-4x/templates/couchdb-nouveau-deployment.yaml
@@ -46,7 +46,11 @@ spec:
           {{- else }}
           volumeMounts:
             - mountPath: /data/nouveau
-              name: couchdb-nouveau-claim0
+              {{- if eq (toString $.Values.couchdb.clusteredCouch_enabled) "true" }}
+              name: couchdb-1-claim0
+              {{- else }}
+              name: couchdb-claim0
+              {{- end }}
               subPath: data
           {{- end }}
       restartPolicy: Always
@@ -57,9 +61,15 @@ spec:
             path: {{ index .Values.local_storage "preExistingDiskPath-1" }}
       {{- else }}
       volumes:
-        - name: couchdb-nouveau-claim0
+        {{- if eq (toString $.Values.couchdb.clusteredCouch_enabled) "true" }}
+        - name: couchdb-1-claim0
           persistentVolumeClaim:
-            claimName: couchdb-nouveau-claim0
+            claimName: couchdb-1-claim0
+        {{- else }}
+        - name: couchdb-claim0
+          persistentVolumeClaim:
+            claimName: couchdb-claim0
+        {{- end }}
       {{- end }}
 status: {}
 {{- end }}

--- a/charts/cht-chart-4x/templates/couchdb-nouveau-deployment.yaml
+++ b/charts/cht-chart-4x/templates/couchdb-nouveau-deployment.yaml
@@ -17,9 +17,6 @@ spec:
       labels:
         cht.service: nouveau
     spec:
-      securityContext:
-        runAsUser: 0  # Run as root
-        fsGroup: 0    # Set fsGroup to root
       tolerations:
         - key: {{ .Values.toleration.key }}
           operator: {{ .Values.toleration.operator }}

--- a/charts/cht-chart-4x/templates/couchdb-nouveau-deployment.yaml
+++ b/charts/cht-chart-4x/templates/couchdb-nouveau-deployment.yaml
@@ -32,9 +32,9 @@ spec:
       {{- end }}
     {{- end }}
       containers:
+        - name: cht-couchdb-nouveau
           image: {{ .Values.upstream_servers.docker_registry }}/cht-couchdb-nouveau:{{ .Values.cht_image_tag }}
           {{ if eq .Values.cache_images false}}imagePullPolicy: Always{{ end }}
-          name: cht-couchdb-nouveau
           ports:
             - containerPort: 5987
           resources: {}

--- a/charts/cht-chart-4x/templates/couchdb-nouveau-service.yaml
+++ b/charts/cht-chart-4x/templates/couchdb-nouveau-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.couchdb.nouveau_enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cht.service: nouveau
+  name: nouveau
+spec:
+  ports:
+    - name: nouveau-service
+      port: 5987
+      protocol: TCP
+      targetPort: 5987
+  selector:
+    cht.service: nouveau
+status:
+  loadBalancer: {}
+{{- end }}


### PR DESCRIPTION
@Hareet please review this change to the helm charts for nouveau

closes #40 

This adds a new pod and service for nouveau.

some notes:

- it does not add a new volume for nouveau data, instead it uses the same volume that couchdb uses. Nouveau is supposed to be mostly transparent, essentially just a part of couchdb, so we don't want to ask deployers to provision space for a separate volume, the size of which will be unknown and difficult to estimate. Also the main point of nouveau is to reduce storage space, so we don't want to have to ask for more instead. For multi-node couchdb this is a little complicated, because of course each couch node has its own volume, but we don't want nouveau to duplicate nouveau data for each node. So one solution is to just use the volume from the first couchdb node. This means both the storage size and IO will be imbalanced; the first node will be larger and busier in terms of IO operations than other nodes. For now, I'm assuming that this won't significant, but its something we should verify somehow; is the performance of the first couchdb node going to be significantly worse because of the extra IO operations from nouveau?
- For the nouveau instance it does add a new pod; if we really wanted to have all the resources for nouveau be combined with couchdb, we could add a nouveau container to each existing couchdb pod, instead of a new pod. This is also a change from the current performance; all freetext searches will use a single nouveau instance even if couchdb is clustered. We should also verify that that won't become a bottleneck, but it seems unlikely.
- Its mounted on a hardcoded subdirectory and will ignore the settings for preexisting data. Which means nouveau indexes will have to rebuild after a new deployment even if using preexisting data, which is a change from previous behavior where views would come along with the other data. But I don't think its worth it to add new settings for nouveau data paths, which no one is going to know or want to care about.
- Nouveau is not behind a feature flag in cht core, so it creates a hard dependency between these helm charts and cht-core; a cht-core above a certain version must be deployed with a helm chart that contains nouveau, and a cht-core below the noveau shouldn't have a nouveau pod. Alhtough a nouveau pod that isn't used isn't that much of a problem. So the nouveau templates have a feature flag in values which default to true; new and upgraded deployments will get nouveau by default but it can be manually turned off if necessary. And we can add a few lines in the deploy script to try and ensure the helm chart version matches the cht-core version.
- I'm not sure what the tolerations are for, so I copied them from the couchdb template.
