### PR TITLE
updated ssl dev cert and cht_image_tags for regular use of helm cli

### DIFF
--- a/charts/cht-chart-4x/values.yaml
+++ b/charts/cht-chart-4x/values.yaml
@@ -1,7 +1,7 @@
 project_name: "<your-project-name>" # e.g. mrjones-dev
 namespace: "<your-namespace>" # e.g. "mrjones-dev"
-chtversion: 4.10.0
-# cht_image_tag: 4.1.1-4.1.1 #- This is filled in automatically by the deploy script. Don't uncomment this line.
+chtversion: 4.18.0
+cht_image_tag: 4.18.0 #- This is filled in automatically by the deploy script. Don't uncomment this line.
 
 # If images are cached, the same image tag will never be pulled twice. For development, this means that it's not
 # possible to upgrade to a newer version of the same branch, as the old image will always be reused.
@@ -34,7 +34,7 @@ ingress:
   annotations:
     groupname: "dev-cht-alb"
     tags: "Environment=dev,Team=QA"
-    certificate: "arn:aws:iam::720541322708:server-certificate/2024-wildcard-dev-medicmobile-org-chain"
+    certificate: "arn:aws:iam::720541322708:server-certificate/2025-q2-wildcard-dev-medicmobile-org-letsencrypt"
   # Ensure the host is not already taken. Valid characters for a subdomain are:
   #   a-z, 0-9, and - (but not as first or last character).
   host: "<subdomain>.dev.medicmobile.org"  # e.g. "mrjones.dev.medicmobile.org"


### PR DESCRIPTION
Deleted all bad entries of ingress annotations and patched them with the correct certificate arn.

This updates the default values so people don't deploy a chart using the old ssl cert and interfere with alb ingress controller reconciliation. 