### PR TITLE
feat: add SECRET_KEY support to cht-user-management chart

### DIFF
--- a/charts/cht-user-management/templates/_secret.tpl
+++ b/charts/cht-user-management/templates/_secret.tpl
@@ -36,3 +36,16 @@ Looks if there is existing secrets and reuse their keys. If not generate new key
 {{- (randAlphaNum 45) | b64enc | quote }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate SECRET_KEY (32 bytes / 64 hex chars), persisted across upgrades.
+This must be hex because the app decrypts using Buffer.from(secretKey, 'hex').
+*/}}
+{{- define "chtUserManagement.SECRET_KEY" -}}
+{{- $secret := (lookup "v1" "Secret" (.Release.Namespace) (include "chtUserManagement.fullname" .) ) }}
+{{- if $secret }}
+{{- index $secret "data" "SECRET_KEY" }}
+{{- else }}
+{{- (randBytes 32 | sha256sum ) | quote }}
+{{- end }}
+{{- end }}

--- a/charts/cht-user-management/templates/secret.yaml
+++ b/charts/cht-user-management/templates/secret.yaml
@@ -8,3 +8,4 @@ type: Opaque
 data:
   COOKIE_PRIVATE_KEY: {{ include "chtUserManagement.COOKIE_PRIVATE_KEY" . }}
   WORKER_PRIVATE_KEY: {{ include "chtUserManagement.WORKER_PRIVATE_KEY" . }}
+  SECRET_KEY: {{ include "chtUserManagement.SECRET_KEY" . }}

--- a/charts/cht-user-management/values.yaml
+++ b/charts/cht-user-management/values.yaml
@@ -19,10 +19,12 @@ cht-user-management:
     REDIS_HOST: test-user-management-redis-master.hareet-test.svc.cluster.local
     REDIS_PORT: 6379
   envSecrets:
-    # COOKIE/WORKER_PRIVATE_KEY will be automatically generated if it doesn't exist
+    # COOKIE/WORKER_PRIVATE_KEY/SECRET_KEY will be automatically generated if it doesn't exist
     - env: COOKIE_PRIVATE_KEY
       secretName: "{{ .Release.Name }}-cht-user-management"
     - env: WORKER_PRIVATE_KEY
+      secretName: "{{ .Release.Name }}-cht-user-management"
+    - env: SECRET_KEY
       secretName: "{{ .Release.Name }}-cht-user-management"
   
   ingress:


### PR DESCRIPTION
Closes #50
This PR adds support for the new SECRET_KEY environment variable recently introduced in cht-user-management.
which is used by the API to encrypt and decrypt upload logs and must be provided as a persistent, hex-encoded secret.
